### PR TITLE
0.35.1 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@ A Crystal wrapper around the [DataStax C/C++
 Driver](https://docs.datastax.com/en/developer/cpp-driver/2.10/). It conforms to
 the [crystal-db](https://github.com/crystal-lang/crystal-db) API.
 
-
 ## Status
 
 This is a personal project to create something meaningful while learning
 Crystal. There are no guarantees about future development, maintenance, or
 support. That said, if you need to use Crystal to query Cassandra this library
 could be a good starting point. YMMV.
-
 
 ## Installation
 
@@ -27,12 +25,10 @@ dependencies:
     github: kaukas/crystal-cassandra
 ```
 
-
 ## Documentation
 
 The [latest Crystal Cassandra API documentation can be found
 here](https://kaukas.github.io/crystal-cassandra/latest/).
-
 
 ## Usage
 
@@ -71,7 +67,6 @@ end
 Please refer to [crystal-db](https://github.com/crystal-lang/crystal-db) for
 further usage instructions.
 
-
 ## Types
 
 `crystal-cassandra` supports [all the
@@ -88,7 +83,6 @@ Some of the collection types are also supported:
 - `list` maps to `Array`
 - `set` maps to `Set`
 - `map` maps to `Hash`
-
 
 ### Casting
 
@@ -134,33 +128,31 @@ end
 but shortcuts are defined for them so `Any` can be skipped (see the [basic
 example](https://github.com/kaukas/crystal-cassandra/blob/master/examples/basic.cr)).
 
-
 ## Development
 
 Install the C/C++ Driver. The `Makefile` commands work on MacOS:
 
 ```bash
-$ make build-cppdriver
+make build-cppdriver
 ```
 
 Start a Docker container with an instance of Cassandra:
 
 ```bash
-$ make start-cassandra
+make start-cassandra
 ```
 
 Run the tests:
 
 ```bash
-$ crystal spec
+crystal spec
 ```
 
 Stop Cassandra when finished:
 
 ```bash
-$ make stop-cassandra
+make stop-cassandra
 ```
-
 
 ## Contributing
 
@@ -169,7 +161,6 @@ $ make stop-cassandra
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
-
 
 ## Contributors
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,12 +4,12 @@ version: 0.1.0
 authors:
   - Linas Juškevičius <linas@prodigito.lt>
 
-crystal: 0.31.0
+crystal: 0.35.1
 
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.7.0
+    version: ~> 0.9.0
 
 development_dependencies:
   crystal_lib:

--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ crystal: 0.35.1
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.9.0
+    version: ~> 0.10.0
 
 development_dependencies:
   crystal_lib:

--- a/spec/cassandra/querying_spec.cr
+++ b/spec/cassandra/querying_spec.cr
@@ -2,6 +2,8 @@ require "../spec_helper"
 require "../../src/cassandra/dbapi"
 
 Spectator.describe "Querying" do
+  let(db) { DBHelper.connect("paging_size=1") }
+
   before_all do
     DBHelper.setup
 
@@ -18,8 +20,6 @@ Spectator.describe "Querying" do
   end
 
   context("pagination") do
-    let(db) { DBHelper.connect("paging_size=1") }
-
     it "performs result page handling automatically" do
       titles = Array.new(5) { |i| i.to_s }.to_set
       titles.each do |title|
@@ -57,7 +57,7 @@ Spectator.describe "Querying" do
       db.exec("insert into books (id, title) values (now(), ?)", "A title")
       # Expect an invalid statement to fail.
       expect_raises(Cassandra::DBApi::PreparedStatement::StatementPrepareError,
-                    /ErrorServerSyntaxError/) do
+        /ErrorServerSyntaxError/) do
         db.exec("do not insert into books (id, title) values (now(), ?)")
       end
     end
@@ -71,7 +71,7 @@ Spectator.describe "Querying" do
       db.exec("insert into books (id, title) values (now(), ?)", "A title")
       # Expect an invalid statement to fail.
       expect_raises(Cassandra::DBApi::StatementError,
-                    /ErrorServerSyntaxError/) do
+        /ErrorServerSyntaxError/) do
         db.exec("do not insert into books (id, title) values (now(), ?)")
       end
     end

--- a/spec/cassandra/session_spec.cr
+++ b/spec/cassandra/session_spec.cr
@@ -12,7 +12,7 @@ Spectator.describe Cassandra::DBApi do
     DB.open(DB_URI)
     # Expect incorrect port to fail.
     expect_raises(Cassandra::DBApi::Session::ConnectError,
-                  /ErrorLibNoHostsAvailable/) do
+      /ErrorLibNoHostsAvailable/) do
       DB.open("cassandra://cassandra:cassandra@127.0.0.1:55")
     end
   end
@@ -35,7 +35,7 @@ Spectator.describe Cassandra::DBApi do
     DB.open("#{DB_URI}/crystal_cassandra_dbapi_test")
     # Expect incorrect keyspace to fail.
     expect_raises(Cassandra::DBApi::Session::ConnectError,
-                  /ErrorLibUnableToSetKeyspace/) do
+      /ErrorLibUnableToSetKeyspace/) do
       DB.open("#{DB_URI}/onaoweingaowifaowinow")
     end
   end
@@ -48,7 +48,7 @@ Spectator.describe Cassandra::DBApi do
     keyspace = URI.encode(%("onaoweingaowifaowinow"))
     # Expect incorrect keyspace to fail.
     expect_raises(Cassandra::DBApi::Session::ConnectError,
-                  /ErrorLibUnableToSetKeyspace/) do
+      /ErrorLibUnableToSetKeyspace/) do
       DB.open("#{DB_URI}/#{keyspace}")
     end
   end
@@ -58,7 +58,7 @@ Spectator.describe Cassandra::DBApi do
     DB.open(DB_URI)
     # Expect incorrect credentials to fail.
     expect_raises(Cassandra::DBApi::Session::ConnectError,
-                  /ErrorServerBadCredentials/) do
+      /ErrorServerBadCredentials/) do
       DB.open("cassandra://incorrect:incorrect@127.0.0.1:9042")
     end
   end

--- a/src/cassandra/dbapi/statement.cr
+++ b/src/cassandra/dbapi/statement.cr
@@ -14,11 +14,11 @@ module Cassandra
       @session : Cassandra::DBApi::Session
 
       def initialize(session, cql : String, paging_size)
-        initialize(session, create_statement(cql), paging_size)
+        initialize(session, create_statement(cql), cql, paging_size)
       end
 
-      def initialize(@session, @cass_statement, paging_size : UInt64?)
-        super(@session)
+      def initialize(@session, @cass_statement, cql : String, paging_size : UInt64?)
+        super(@session, cql)
         if paging_size
           LibCass.statement_set_paging_size(@cass_statement, paging_size)
         end
@@ -77,10 +77,10 @@ module Cassandra
       def initialize(@session : DBApi::Session,
                      cql : String,
                      paging_size : UInt64?)
-        super(@session)
+        super(@session, cql)
         @cass_prepared = prepare(@session, cql)
         cass_statement = create_statement(@cass_prepared)
-        @statement = RawStatement.new(@session, cass_statement, paging_size)
+        @statement = RawStatement.new(@session, cass_statement, cql, paging_size)
       end
 
       def do_close


### PR DESCRIPTION
Updated to crystal 0.35.1 and db 0.9.0

Minor markdown lint fixes as well: [MD012](https://github.com/DavidAnson/markdownlint/blob/v0.21.0/doc/Rules.md#md012) and [MD014](https://github.com/DavidAnson/markdownlint/blob/v0.21.0/doc/Rules.md#md014)